### PR TITLE
fix: touch device text input missing for high scores (#84)

### DIFF
--- a/games_repo/CHANGELOG.md
+++ b/games_repo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the games in this monorepo will be documented in this file. This project uses [CalVer](https://calver.org/) for versioning.
 
-## [26.4.9.229] - 2026-04-09
+## [26.4.9.230] - 2026-04-09
 ### Fixed
 - **Touch Device Text Input:** Restored the ability for iPad and other touch device users to enter their names for high scores.
   - Replaced restrictive screen-size-based mobile detection with a more robust user-agent and touch-point heuristic in `shared` library.

--- a/games_repo/CHANGELOG.md
+++ b/games_repo/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the games in this monorepo will be documented in this file. This project uses [CalVer](https://calver.org/) for versioning.
 
-## [26.4.9.230] - 2026-04-09
+## [26.4.9.232] - 2026-04-09
 ### Fixed
+- **Optimization:** Cached `is_mobile()` calls in `bubbles`, `zookeeper`, and `lumines` to avoid inefficient WASM-to-JS bridge calls and heap allocations in the main loop.
+- **WASM UX:** Gated the "TAP FOR POPUP" UI on `wasm32` target in `bubbles`, `zookeeper`, and `lumines` to prevent non-functional buttons on small-window non-wasm builds.
 - **Touch Device Text Input:** Restored the ability for iPad and other touch device users to enter their names for high scores.
   - Replaced restrictive screen-size-based mobile detection with a more robust user-agent and touch-point heuristic in `shared` library.
   - Added missing `js_get_user_agent_ptr` bridge to `index.html` for Zookeeper and Bubbles.

--- a/games_repo/CHANGELOG.md
+++ b/games_repo/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the games in this monorepo will be documented in this file. This project uses [CalVer](https://calver.org/) for versioning.
 
+## [26.4.9.229] - 2026-04-09
+### Fixed
+- **Touch Device Text Input:** Restored the ability for iPad and other touch device users to enter their names for high scores.
+  - Replaced restrictive screen-size-based mobile detection with a more robust user-agent and touch-point heuristic in `shared` library.
+  - Added missing `js_get_user_agent_ptr` bridge to `index.html` for Zookeeper and Bubbles.
+  - Improved `js_get_user_agent_ptr` to correctly identify iPads even when running in "Desktop Mode" (Safari default).
+  - Updated Bubbles to use the shared `update_with_touch` name entry logic for consistency across all games.
+
 ## [26.4.7.228] - 2026-04-07
 ### Added
 - **Lumines WASM Difficulty Progression:** Deepened the challenge mode mechanics to match original Lumines games.

--- a/games_repo/games/bubbles/Cargo.toml
+++ b/games_repo/games/bubbles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bubbles"
-version = "26.4.7"
+version = "26.4.9"
 edition = "2021"
 
 [dependencies]

--- a/games_repo/games/bubbles/index.html
+++ b/games_repo/games/bubbles/index.html
@@ -109,6 +109,16 @@
                     heap.set(bytes.subarray(0, len), ptr);
                     return len;
                 };
+                importObject.env.js_get_user_agent_ptr = function (ptr, max_len) {
+                    const ua = navigator.userAgent;
+                    const isIPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+                    const fullUA = ua + (isIPad ? " iPad" : "");
+                    const bytes = new TextEncoder().encode(fullUA);
+                    const len = Math.min(bytes.length, max_len);
+                    const heap = new Uint8Array((importObject.env.memory || wasm_memory).buffer);
+                    heap.set(bytes.subarray(0, len), ptr);
+                    return len;
+                };
             }
         });
 

--- a/games_repo/games/bubbles/src/main.rs
+++ b/games_repo/games/bubbles/src/main.rs
@@ -28,6 +28,7 @@ async fn main() {
     let mut game = Game::new(false);
     let mut state = AppState::Menu;
     let mut two_player = false;
+    let is_mobile = shared::touch_input::is_mobile();
 
     loop {
         // Dynamic virtual height: only reserve space for controls if touch is active
@@ -100,7 +101,7 @@ async fn main() {
                 let submitted = input.update_with_touch(
                     (btn_x, js_btn_y, btn_w, btn_h),
                     (btn_x, btn_y, btn_w, btn_h),
-                    shared::touch_input::is_mobile(),
+                    is_mobile,
                 );
 
                 if submitted {
@@ -173,7 +174,7 @@ async fn main() {
                 let btn_h = 30.0 * scale;
                 let btn_x = vx + (VIRTUAL_WIDTH / 2.0) * scale - btn_w / 2.0;
                 
-                if shared::touch_input::is_mobile() {
+                if is_mobile && cfg!(target_arch = "wasm32") {
                     draw_rectangle(btn_x, vy + 140.0 * scale, btn_w, btn_h, Color::new(0.2, 0.2, 0.2, 1.0));
                     draw_text("TAP FOR POPUP", btn_x + 5.0 * scale, vy + 160.0 * scale, 12.0 * scale, WHITE);
                 }

--- a/games_repo/games/bubbles/src/main.rs
+++ b/games_repo/games/bubbles/src/main.rs
@@ -85,8 +85,6 @@ async fn main() {
                 }
             }
             AppState::EnteringName { ref mut input } => {
-                let mut submitted = input.update();
-                
                 // UI calculations
                 let sw = screen_width();
                 let sh = screen_height();
@@ -97,19 +95,13 @@ async fn main() {
                 let btn_h = 30.0 * scale;
                 let btn_x = vx + (VIRTUAL_WIDTH / 2.0) * scale - btn_w / 2.0;
                 let btn_y = vy + 180.0 * scale;
+                let js_btn_y = vy + 140.0 * scale;
 
-                if is_mouse_button_pressed(MouseButton::Left) {
-                    let (mx, my) = mouse_position();
-                    if mx >= btn_x && mx <= btn_x + btn_w && my >= btn_y && my <= btn_y + btn_h {
-                        submitted = true;
-                    }
-                    
-                    // JS Prompt button
-                    let js_btn_y = vy + 140.0 * scale;
-                    if mx >= btn_x && mx <= btn_x + btn_w && my >= js_btn_y && my <= js_btn_y + btn_h {
-                        input.content = storage::ask_name_js();
-                    }
-                }
+                let submitted = input.update_with_touch(
+                    (btn_x, js_btn_y, btn_w, btn_h),
+                    (btn_x, btn_y, btn_w, btn_h),
+                    shared::touch_input::is_mobile(),
+                );
 
                 if submitted {
                     let final_name = if input.content.is_empty() { "BUB".to_string() } else { input.content.clone() };
@@ -181,8 +173,10 @@ async fn main() {
                 let btn_h = 30.0 * scale;
                 let btn_x = vx + (VIRTUAL_WIDTH / 2.0) * scale - btn_w / 2.0;
                 
-                draw_rectangle(btn_x, vy + 140.0 * scale, btn_w, btn_h, Color::new(0.2, 0.2, 0.2, 1.0));
-                draw_text("TAP FOR POPUP", btn_x + 5.0 * scale, vy + 160.0 * scale, 12.0 * scale, WHITE);
+                if shared::touch_input::is_mobile() {
+                    draw_rectangle(btn_x, vy + 140.0 * scale, btn_w, btn_h, Color::new(0.2, 0.2, 0.2, 1.0));
+                    draw_text("TAP FOR POPUP", btn_x + 5.0 * scale, vy + 160.0 * scale, 12.0 * scale, WHITE);
+                }
 
                 draw_rectangle(btn_x, vy + 180.0 * scale, btn_w, btn_h, Color::new(0.3, 0.8, 0.3, 1.0));
                 draw_text("OK", btn_x + 40.0 * scale, vy + 200.0 * scale, 20.0 * scale, WHITE);

--- a/games_repo/games/bubbles/src/storage.rs
+++ b/games_repo/games/bubbles/src/storage.rs
@@ -6,10 +6,6 @@ pub struct ScoreEntry {
     pub score: u32,
 }
 
-pub fn ask_name_js() -> String {
-    shared::leaderboard::ask_player_name("BUB")
-}
-
 pub fn load_scores() -> Vec<ScoreEntry> {
     shared::leaderboard::load_scores()
 }

--- a/games_repo/games/jetpac/Cargo.toml
+++ b/games_repo/games/jetpac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetpac"
-version = "26.4.7"
+version = "26.4.9"
 edition = "2021"
 
 [dependencies]

--- a/games_repo/games/lumines/Cargo.toml
+++ b/games_repo/games/lumines/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumines_wasm"
-version = "26.4.7"
+version = "26.4.9"
 edition = "2021"
 
 [dependencies]

--- a/games_repo/games/lumines/index.html
+++ b/games_repo/games/lumines/index.html
@@ -89,8 +89,8 @@
                     const fullUA = ua + (isIPad ? " iPad" : "");
                     const bytes = new TextEncoder().encode(fullUA);
                     const len = Math.min(bytes.length, max_len);
-                    const memory = new Uint8Array((importObject.env.memory || wasm_memory).buffer);
-                    memory.set(bytes.slice(0, len), ptr);
+                    const heap = new Uint8Array((importObject.env.memory || wasm_memory).buffer);
+                    heap.set(bytes.subarray(0, len), ptr);
                     return len;
                 };
             }

--- a/games_repo/games/lumines/index.html
+++ b/games_repo/games/lumines/index.html
@@ -85,7 +85,9 @@
 
                 importObject.env.js_get_user_agent_ptr = function(ptr, max_len) {
                     const ua = navigator.userAgent;
-                    const bytes = new TextEncoder().encode(ua);
+                    const isIPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+                    const fullUA = ua + (isIPad ? " iPad" : "");
+                    const bytes = new TextEncoder().encode(fullUA);
                     const len = Math.min(bytes.length, max_len);
                     const memory = new Uint8Array((importObject.env.memory || wasm_memory).buffer);
                     memory.set(bytes.slice(0, len), ptr);

--- a/games_repo/games/lumines/src/main.rs
+++ b/games_repo/games/lumines/src/main.rs
@@ -11,7 +11,7 @@ use shared::theme::{BlockColor, BlockShape};
 
 const COLS: usize = 16;
 const ROWS: usize = 10;
-const VERSION: &str = "26.04.09.230";
+const VERSION: &str = "26.04.09.232";
 
 
 const BEATS_PER_SWEEP: f32 = 8.0;
@@ -2082,7 +2082,8 @@ impl Game {
 #[macroquad::main("Lumines WASM")]
 async fn main() {
     qrand::srand(macroquad::miniquad::date::now() as _);
-    let mut game = Game::new().await;
+    let is_mobile = shared::touch_input::is_mobile();
+    let mut game = Game::new(is_mobile).await;
 
     loop {
         clear_background(BLACK);
@@ -2121,7 +2122,7 @@ async fn main() {
 
             let audio = game.audio;
             let muted = audio.is_muted();
-            game = Game::new().await;
+            game = Game::new(is_mobile).await;
             game.audio = audio;
             game.audio.set_muted(muted);
             game.waiting_to_start = false;

--- a/games_repo/games/lumines/src/main.rs
+++ b/games_repo/games/lumines/src/main.rs
@@ -11,7 +11,7 @@ use shared::theme::{BlockColor, BlockShape};
 
 const COLS: usize = 16;
 const ROWS: usize = 10;
-const VERSION: &str = "26.04.09.229";
+const VERSION: &str = "26.04.09.230";
 
 
 const BEATS_PER_SWEEP: f32 = 8.0;

--- a/games_repo/games/lumines/src/main.rs
+++ b/games_repo/games/lumines/src/main.rs
@@ -11,7 +11,7 @@ use shared::theme::{BlockColor, BlockShape};
 
 const COLS: usize = 16;
 const ROWS: usize = 10;
-const VERSION: &str = "26.04.07.228";
+const VERSION: &str = "26.04.09.229";
 
 
 const BEATS_PER_SWEEP: f32 = 8.0;

--- a/games_repo/games/music_editor/Cargo.toml
+++ b/games_repo/games/music_editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "music_editor_wasm"
-version = "26.4.7"
+version = "26.4.9"
 edition = "2021"
 
 [dependencies]

--- a/games_repo/games/music_editor/Makefile
+++ b/games_repo/games/music_editor/Makefile
@@ -1,4 +1,4 @@
-VERSION=26.4.7.228
+VERSION=26.4.9.229
 
 .PHONY: build serve
 

--- a/games_repo/games/music_editor/Makefile
+++ b/games_repo/games/music_editor/Makefile
@@ -1,4 +1,4 @@
-VERSION=26.4.9.230
+VERSION=26.4.9.232
 
 .PHONY: build serve
 

--- a/games_repo/games/music_editor/Makefile
+++ b/games_repo/games/music_editor/Makefile
@@ -1,4 +1,4 @@
-VERSION=26.4.9.229
+VERSION=26.4.9.230
 
 .PHONY: build serve
 

--- a/games_repo/games/shared/src/touch_input.rs
+++ b/games_repo/games/shared/src/touch_input.rs
@@ -17,7 +17,12 @@ pub fn is_mobile() -> bool {
         // On WASM, we can check the user agent via JS.
         // This is a common pattern in Macroquad projects using miniquad.
         let ua = unsafe { js_get_user_agent() };
-        ua.contains("Mobi") || ua.contains("Android") || ua.contains("iPhone") || ua.contains("iPad")
+        ua.contains("Mobi")
+            || ua.contains("Android")
+            || ua.contains("iPhone")
+            || ua.contains("iPad")
+            || ua.contains("Touch")
+            || ua.contains("Tablet")
     }
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/games_repo/games/zookeeper/Cargo.toml
+++ b/games_repo/games/zookeeper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zookeeper_wasm"
-version = "26.4.7"
+version = "26.4.9"
 edition = "2021"
 
 [dependencies]

--- a/games_repo/games/zookeeper/index.html
+++ b/games_repo/games/zookeeper/index.html
@@ -110,6 +110,16 @@
                     heap.set(bytes.subarray(0, len), ptr);
                     return len;
                 };
+                importObject.env.js_get_user_agent_ptr = function (ptr, max_len) {
+                    const ua = navigator.userAgent;
+                    const isIPad = (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+                    const fullUA = ua + (isIPad ? " iPad" : "");
+                    const bytes = new TextEncoder().encode(fullUA);
+                    const len = Math.min(bytes.length, max_len);
+                    const heap = new Uint8Array((importObject.env.memory || wasm_memory).buffer);
+                    heap.set(bytes.subarray(0, len), ptr);
+                    return len;
+                };
             }
         });
 

--- a/games_repo/games/zookeeper/src/main.rs
+++ b/games_repo/games/zookeeper/src/main.rs
@@ -16,7 +16,7 @@ const COLS: usize = 8;
 /// The standard grid height for the game board.
 const ROWS: usize = 8;
 /// The game version (CalVer).
-const VERSION: &str = "26.3.300177";
+const VERSION: &str = "26.04.09.232";
 
 // Animation Constants
 const LEVEL_UP_TOTAL_DELAY: f32 = 1.0;

--- a/games_repo/games/zookeeper/src/main.rs
+++ b/games_repo/games/zookeeper/src/main.rs
@@ -1692,8 +1692,7 @@ async fn main() {
 
             #[cfg(target_arch = "wasm32")]
             {
-                let is_mobile = sw < 600.0 && sw < sh;
-                if is_mobile {
+                if shared::touch_input::is_mobile() {
                     let prompt_w = sw * 0.4;
                     let prompt_x = sw / 2.0 - prompt_w / 2.0;
                     let prompt_y = sh * 0.6;


### PR DESCRIPTION
Restores the ability for iPad and other touch device users to enter their names for high scores.

Changes:
- Replaced restrictive screen-size based mobile detection with a robust user-agent and touch-point heuristic in `shared` library.
- Added missing `js_get_user_agent_ptr` bridge to `index.html` for Zookeeper and Bubbles.
- Improved `js_get_user_agent_ptr` to correctly identify iPads even when running in "Desktop Mode" (Safari default).
- Updated Bubbles to use the shared `update_with_touch` name entry logic for consistency across all games.
- Bumped version to 26.4.9.229.

Fixes #84