### PR TITLE
fix(kissagotchi): move name input label to bottom of screen

### DIFF
--- a/games_repo/CHANGELOG.md
+++ b/games_repo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the games in this monorepo will be documented in this file. This project uses [CalVer](https://calver.org/) for versioning.
 
-## [26.5.31.271] - 2026-05-30
+## [26.5.31.272] - 2026-05-30
 ### Added
 - **Kissagotchi**: Added Day/Night cycle background color changes.
 - **Kissagotchi**: Added Age and Weight mechanics that visually alter the cat's face (kitten, adult, fat).

--- a/games_repo/games/bubbles/src/main.rs
+++ b/games_repo/games/bubbles/src/main.rs
@@ -11,7 +11,7 @@ use crate::input::InputManager;
 use macroquad::prelude::*;
 
 #[allow(dead_code)]
-const VERSION: &str = "26.05.31.271";
+const VERSION: &str = "26.05.31.272";
 
 #[derive(Clone, PartialEq, Debug)]
 enum AppState {

--- a/games_repo/games/gravitris/src/main.rs
+++ b/games_repo/games/gravitris/src/main.rs
@@ -7,7 +7,7 @@ use crate::game::{Board, Difficulty, COLS, ROWS};
 use crate::input::InputManager;
 use macroquad::prelude::*;
 
-const VERSION: &str = "26.05.31.271";
+const VERSION: &str = "26.05.31.272";
 
 #[derive(Clone, PartialEq, Debug)]
 enum AppState {

--- a/games_repo/games/kissagotchi/src/main.rs
+++ b/games_repo/games/kissagotchi/src/main.rs
@@ -279,7 +279,7 @@ async fn main() {
 
         if !in_minigame {
             name_input.update_with_touch(
-                (w / 2.0 - 100.0, 20.0, 200.0, 40.0),
+                (w / 2.0 - 100.0, h - 110.0, 200.0, 40.0),
                 (0.0, 0.0, 0.0, 0.0),
                 is_mobile,
             );
@@ -618,7 +618,7 @@ async fn main() {
 
         // Draw Name Input Box
         let input_rect_x = w / 2.0 - 100.0;
-        let input_rect_y = 20.0;
+        let input_rect_y = h - 110.0;
         let input_rect_w = 200.0;
         let input_rect_h = 40.0;
         draw_rectangle(input_rect_x, input_rect_y, input_rect_w, input_rect_h, Color::new(0.2, 0.2, 0.3, 1.0));

--- a/games_repo/games/lumines/src/main.rs
+++ b/games_repo/games/lumines/src/main.rs
@@ -11,7 +11,7 @@ use shared::theme::{BlockColor, BlockShape};
 
 const COLS: usize = 16;
 const ROWS: usize = 10;
-const VERSION: &str = "26.05.31.271";
+const VERSION: &str = "26.05.31.272";
 
 const BEATS_PER_SWEEP: f32 = 8.0;
 const FREEZE_DURATION: f32 = 4.0;

--- a/games_repo/games/music_editor/Makefile
+++ b/games_repo/games/music_editor/Makefile
@@ -1,4 +1,4 @@
-VERSION=26.5.31.271
+VERSION=26.5.31.272
 
 
 .PHONY: build serve test lint

--- a/games_repo/games/zookeeper/src/main.rs
+++ b/games_repo/games/zookeeper/src/main.rs
@@ -17,7 +17,7 @@ const COLS: usize = 8;
 /// The standard grid height for the game board.
 const ROWS: usize = 8;
 /// The game version (CalVer).
-const VERSION: &str = "26.05.31.271";
+const VERSION: &str = "26.05.31.272";
 
 // Animation Constants
 const LEVEL_UP_TOTAL_DELAY: f32 = 1.0;


### PR DESCRIPTION
Moves the name label and input box to the bottom of the screen (above the buttons) to avoid overlapping with stats gauges.